### PR TITLE
Fix "No module Found" error

### DIFF
--- a/data/data.py
+++ b/data/data.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 import time as t
-import nfl_api_parser as nflparser
+import data.nfl_api_parser as nflparser
 import debug
 
 NETWORK_RETRY_SLEEP_TIME = 10.0


### PR DESCRIPTION
To fix the error

```Traceback (most recent call last):
  File "/home/pi/nfl-led-scoreboard/main.py", line 6, in <module>
    from data.data import Data
  File "/home/pi/nfl-led-scoreboard/data/data.py", line 3, in <module>
    import nfl_api_parser as nflparser
ModuleNotFoundError: No module named 'nfl_api_parser'```

We need to add a "data." that python3 can find the module.